### PR TITLE
changed project name in package.json to fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "MEAN Scaffold",
+  "name": "mean-scaffold",
   "version": "1.0.0",
   "description": "",
   "main": "server.js",


### PR DESCRIPTION
npm install was giving an error due to the capital letters and space in the name field of package.json